### PR TITLE
Resolve OpenDSS Redirect Issue.

### DIFF
--- a/src/i2x/opendss_interface.py
+++ b/src/i2x/opendss_interface.py
@@ -32,7 +32,7 @@ def run_opendss(choice, pvcurve, loadmult, stepsize, numsteps,
 
   pkg.resource_listdir (__name__, 'models/{:s}'.format(choice))
 
-  dss_line (dss, 'compile {:s}/HCABase.dss'.format (fdr_path))
+  dss_line (dss, 'compile "{:s}/HCABase.dss"'.format (fdr_path))
 
   if change_lines is not None:
     for line in change_lines:


### PR DESCRIPTION
Regarding Issue #4 the problem is that if the software is located on a path with a space in the name, openDSS' parsing fails.
This is resolved by adding double quotes around the commit call:
```
dss_line (dss, 'compile "{:s}/HCABase.dss"'.format (fdr_path))
```

This Closes #4 