### PR TITLE
Adding plotly option to emt bootcamp notebook

### DIFF
--- a/emt-bootcamp/README.md
+++ b/emt-bootcamp/README.md
@@ -33,7 +33,7 @@ examples in this bootcamp. To prepare your computer for these examples:
 2. Install the Python support packages as necessary:
    - Open a **Command Prompt** from the Start / Windows System menu.
    - Enter **pip install matplotlib scipy plotly** for plotting and numerical support, see [Matplotlib](https://matplotlib.org/), [numpy](https://numpy.org/doc/stable/user/index.html), and [scipy](https://scipy.org/), [plotly](https://plotly.com/python/getting-started/).
-   - Enter **pip install jupyter ipympl** for a browser-based interface to Python, see [Jupyter Notebook](https://jupyter.org).
+   - Enter **pip install jupyter ipympl ipywidgets** for a browser-based interface to Python, see [Jupyter Notebook](https://jupyter.org).
 
 To test these installations:
 

--- a/emt-bootcamp/README.md
+++ b/emt-bootcamp/README.md
@@ -32,7 +32,7 @@ examples in this bootcamp. To prepare your computer for these examples:
    - On the second panel of Python 3's installer, **select the option** that adds Python variables to your system environment, which includes the **path**.
 2. Install the Python support packages as necessary:
    - Open a **Command Prompt** from the Start / Windows System menu.
-   - Enter **pip install matplotlib scipy** for plotting and numerical support, see [Matplotlib](https://matplotlib.org/), [numpy](https://numpy.org/doc/stable/user/index.html), and [scipy](https://scipy.org/).
+   - Enter **pip install matplotlib scipy plotly** for plotting and numerical support, see [Matplotlib](https://matplotlib.org/), [numpy](https://numpy.org/doc/stable/user/index.html), and [scipy](https://scipy.org/), [plotly](https://plotly.com/python/getting-started/).
    - Enter **pip install jupyter ipympl** for a browser-based interface to Python, see [Jupyter Notebook](https://jupyter.org).
 
 To test these installations:

--- a/emt-bootcamp/python/cplot.ipynb
+++ b/emt-bootcamp/python/cplot.ipynb
@@ -13,6 +13,8 @@
     "import numpy as np\n",
     "import math\n",
     "from comtrade import Comtrade\n",
+    "import plotly.graph_objects as go\n",
+    "import plotly.express as px\n",
     "plt.rcParams['savefig.directory'] = os.getcwd()\n",
     "\n",
     "# change this to match the exported COMTRADE file\n",
@@ -56,7 +58,24 @@
     "    return 1.0\n",
     "  elif 'V' in lbl:\n",
     "    return 1.0 / kVLNbase / math.sqrt(2.0)\n",
-    "  return 1.0"
+    "  return 1.0\n",
+    "\n",
+    "\n",
+    "class ColorList:\n",
+    "    def __init__(self):\n",
+    "        self.cidx = 0\n",
+    "        self.colors = px.colors.qualitative.Plotly\n",
+    "        self.n = len(self.colors)\n",
+    "    def __call__(self):\n",
+    "        return self.colors[self.cidx]\n",
+    "    def step(self):\n",
+    "        self.cidx = (self.cidx + 1) % self.n\n",
+    "    def setidx(self, cidx):\n",
+    "        self.cidx = cidx\n",
+    "    def getidx(self):\n",
+    "        return self.cidx\n",
+    "    def shiftidx(self, shift):\n",
+    "        self.cidx = (self.cidx + shift) % self.n"
    ]
   },
   {
@@ -69,6 +88,50 @@
     "print ('Channel           Min        Max       Mean')\n",
     "for key, val in channels.items():\n",
     "    print ('{:10s} {:10.4f} {:10.4f} {:10.4f}'.format (key, np.min(val), np.max(val), np.mean(val)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d35ddfbb",
+   "metadata": {},
+   "source": [
+    "Run the following cell to generate the plot using [Plotly](https://plotly.com/python/getting-started/) an interactive plotting library."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47487011",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = go.Figure().set_subplots(3, 1, shared_xaxes=True, x_title=\"Time [s]\")\n",
+    "labels = [lbl for lbl in channels]\n",
+    "colors = ColorList()\n",
+    "for i in range(3):\n",
+    "    if i < 2:\n",
+    "        colors.setidx(0)\n",
+    "    for j in range(3):\n",
+    "        label = labels[3*i + j]\n",
+    "        fig.add_trace(go.Scatter(x=t, y=scale_factor(label)*channels[label],\n",
+    "                                 name=label, line_color=colors()),\n",
+    "                                 row=i+1, col=1)\n",
+    "        colors.step()\n",
+    "fig.update_layout(title='Case: ' + root, template=\"simple_white\", width=1200, height=1000)\n",
+    "fig.update_xaxes(showgrid=True, minor_showgrid=True)\n",
+    "fig.update_yaxes(showgrid=True, minor_showgrid=True)\n",
+    "#### Display/Save\n",
+    "## uncomment the line below to save the plot to an html file (still interactive) that can be opened later\n",
+    "# fig.write_html(os.path.join(os.getcwd(), \"comtrade_plot_test.html\")) \n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8e9e760",
+   "metadata": {},
+   "source": [
+    "Run the following cell to generate the plots using [Matplotlib](https://matplotlib.org/)"
    ]
   },
   {
@@ -130,7 +193,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Plotting with Plotly instead of Matplot lib which enables more interactive features as well as saving to an interactive figure (html)

Example output:
Full output:
![newplot (25)](https://github.com/pnnl/i2x/assets/28018315/ef776e6b-db3c-4790-b7ba-b87b2e0ad5cc)

Zoomed in:
![newplot (26)](https://github.com/pnnl/i2x/assets/28018315/d6d4e882-14c9-4dfb-8959-91fd782f7516)

Just phase A:
![newplot (27)](https://github.com/pnnl/i2x/assets/28018315/d289b05c-2bc4-4b4e-8c34-47e19a886168)
